### PR TITLE
Style/37 responsive fact page tf

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,13 +50,13 @@
 
     <main class="fact-page hidden">
       <section class="fact-area">
-        <img class="chuck-approved-stamp">
+        <img class="chuck-approved-stamp" src="images/chuck-approved.png" alt="">
         <div class="fact-background">
           <div id="category-fact">
             <!-- Category Fact -->
           </div>
         </div>
-        <img class="autograph">
+        <img class="autograph" src="images/autograph.png" alt="">
       </section>
       <section class="next-area" id="next" title="Next Fact">
           <p class="next-text">Next</p>

--- a/index.html
+++ b/index.html
@@ -49,16 +49,18 @@
     </main>
 
     <main class="fact-page hidden">
-      <div class="chuck-approved"></div>
-      <div class="fact-container">
-        <div id="category-fact">
-          <!-- Category Joke -->
+      <section class="fact-area">
+        <img class="chuck-approved-stamp">
+        <div class="fact-background">
+          <div id="category-fact">
+            <!-- Category Fact -->
+          </div>
         </div>
-      </div>
-      <div class="autograph"></div>
-      <div class="next-container" id="next" title="Next Fact">
-        <p class="next-text">Next</p>
-      </div>
+        <img class="autograph">
+      </section>
+      <section class="next-area" id="next" title="Next Fact">
+          <p class="next-text">Next</p>
+      </section>
     </main>
 
     <section class="members">

--- a/style.css
+++ b/style.css
@@ -192,6 +192,8 @@ hr {
 @media screen and (max-width: 600px) {
   .fact-background {
     width: 75vw;
+    min-height: 10vh;
+  }
   .chuck-approved-stamp {
     display: none;
   }

--- a/style.css
+++ b/style.css
@@ -162,6 +162,7 @@ hr {
   width: inherit;
   height: inherit;
   padding: 2rem;
+  padding-bottom: 3rem;
   font-size: 1.8rem;
 }
 .autograph {

--- a/style.css
+++ b/style.css
@@ -178,6 +178,15 @@ hr {
   margin-left: 6rem;
   font-size: 1.5rem;
 }
+@media screen and (max-width: 600px) {
+  .fact-background {
+    width: 75vw;
+  }
+  #category-fact {
+    padding: 1.5rem;
+    font-size: 1rem;
+  }
+}
 
 /* hide elements */
 .hidden {

--- a/style.css
+++ b/style.css
@@ -138,7 +138,7 @@ hr {
   justify-content: center;
   align-items: center;
 }
-.chuck-approved {
+.chuck-approved-stamp {
   position: absolute;
   width: 22vw;
   height: 22vw;
@@ -146,7 +146,7 @@ hr {
   left: 7rem;
   transform: rotate(-8.96deg);
 }
-.fact-container {
+.fact-background {
   width: 53vw;
   height: 43vh;
   background: var(--primary-color);
@@ -167,7 +167,7 @@ hr {
   left: 30em;
   z-index: 2;
 }
-.next-container {
+.next-area {
   width: 10rem;
   height: 8rem;
   position: absolute;
@@ -177,7 +177,7 @@ hr {
   background-size: contain;
   cursor: pointer;
 }
-.next-container p {
+.next-area p {
   margin-top: 4rem;
   margin-left: 6rem;
   font-size: 1.5rem;

--- a/style.css
+++ b/style.css
@@ -138,6 +138,10 @@ hr {
   justify-content: center;
   align-items: center;
 }
+.fact-area {
+  display: flex;
+  flex-direction: column;
+}
 .chuck-approved-stamp {
   width: 22vw;
   height: 22vw;

--- a/style.css
+++ b/style.css
@@ -192,6 +192,8 @@ hr {
 @media screen and (max-width: 600px) {
   .fact-background {
     width: 75vw;
+  .chuck-approved-stamp {
+    display: none;
   }
   #category-fact {
     padding: 1.5rem;

--- a/style.css
+++ b/style.css
@@ -132,7 +132,7 @@ hr {
 /* CSS for Fact Page */
 .fact-page {
   width: 100vw;
-  position: relative;
+  height: 100vh;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/style.css
+++ b/style.css
@@ -189,13 +189,15 @@ hr {
   margin-left: 6rem;
   font-size: 1.5rem;
 }
+@media screen and (max-width: 800px) {
+  .chuck-approved-stamp {
+    display: none;
+  }
+}
 @media screen and (max-width: 600px) {
   .fact-background {
     width: 75vw;
     min-height: 10vh;
-  }
-  .chuck-approved-stamp {
-    display: none;
   }
   #category-fact {
     padding: 3rem 1.5rem;

--- a/style.css
+++ b/style.css
@@ -198,8 +198,8 @@ hr {
     display: none;
   }
   #category-fact {
-    padding: 1.5rem;
-    font-size: 1rem;
+    padding: 3rem 1.5rem;
+    font-size: 1.2rem;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -165,6 +165,7 @@ hr {
 .autograph {
   width: 32vw;
   height: 20vh;
+  align-self: flex-end;
   z-index: 2;
 }
 .next-area {

--- a/style.css
+++ b/style.css
@@ -145,6 +145,9 @@ hr {
 .chuck-approved-stamp {
   width: 22vw;
   height: 22vw;
+  position: absolute;
+  top: -11vw;
+  left: -15vw;
   transform: rotate(-8.96deg);
 }
 .fact-background {

--- a/style.css
+++ b/style.css
@@ -138,6 +138,7 @@ hr {
   align-items: center;
 }
 .fact-area {
+  position: relative;
   display: flex;
   flex-direction: column;
 }

--- a/style.css
+++ b/style.css
@@ -171,6 +171,7 @@ hr {
   align-self: flex-end;
   position: relative;
   bottom: 10vh;
+  object-fit: contain;
   z-index: 2;
 }
 .next-area {

--- a/style.css
+++ b/style.css
@@ -139,11 +139,8 @@ hr {
   align-items: center;
 }
 .chuck-approved-stamp {
-  position: absolute;
   width: 22vw;
   height: 22vw;
-  top: 3rem;
-  left: 7rem;
   transform: rotate(-8.96deg);
 }
 .fact-background {
@@ -162,9 +159,6 @@ hr {
 .autograph {
   width: 32vw;
   height: 20vh;
-  position: absolute;
-  top: 21.5em;
-  left: 30em;
   z-index: 2;
 }
 .next-area {

--- a/style.css
+++ b/style.css
@@ -139,6 +139,7 @@ hr {
 }
 .fact-area {
   position: relative;
+  top: 5vw;
   display: flex;
   flex-direction: column;
 }

--- a/style.css
+++ b/style.css
@@ -166,6 +166,8 @@ hr {
   width: 32vw;
   height: 20vh;
   align-self: flex-end;
+  position: relative;
+  bottom: 10vh;
   z-index: 2;
 }
 .next-area {

--- a/style.css
+++ b/style.css
@@ -132,7 +132,6 @@ hr {
 /* CSS for Fact Page */
 .fact-page {
   width: 100vw;
-  height: 100vh;
   position: relative;
   display: flex;
   justify-content: center;
@@ -149,7 +148,6 @@ hr {
 }
 .fact-background {
   width: 53vw;
-  height: 43vh;
   background: var(--primary-color);
   border-radius: 10px;
   z-index: 1;

--- a/style.css
+++ b/style.css
@@ -144,8 +144,6 @@ hr {
   height: 22vw;
   top: 3rem;
   left: 7rem;
-  background: url("images/chuck-approved.png") center no-repeat;
-  background-size: contain;
   transform: rotate(-8.96deg);
 }
 .fact-container {
@@ -167,8 +165,6 @@ hr {
   position: absolute;
   top: 21.5em;
   left: 30em;
-  background: url("images/autograph.png") center no-repeat;
-  background-size: contain;
   z-index: 2;
 }
 .next-container {

--- a/style.css
+++ b/style.css
@@ -153,6 +153,7 @@ hr {
 }
 .fact-background {
   width: 53vw;
+  min-height: 30vh;
   background: var(--primary-color);
   border-radius: 10px;
   z-index: 1;


### PR DESCRIPTION
Make fact page responsive.  Divide page into two areas.  First is the fact-area which includes the stamp, the background rectangle that will hold the fact, and the autograph.  The stamp and autograph are moved relative to the fact-area instead of relative to the window, so the grouping doesn't break as screen size is decreased.

As screen size is decreased, and the background rectangle narrows and gets tall, the stamp will begin to fall off the top of the screen.  This happens around 800px for a long fact.  Hide stamp with a media query at 800px.

At 600px, use a media query to increase width of background rectangle with respect to screen and decrease font-size.

The second area, next-area, is still positioned absolutely.